### PR TITLE
Fix broken reference to nagios server log file

### DIFF
--- a/nagios/server/init.sls
+++ b/nagios/server/init.sls
@@ -55,7 +55,7 @@ nagios-user:
 
 nagios-server-log:
   file.managed:
-    - name: {{ map.nagios_server_log }}
+    - name: {{ map.nagios_log }}
     - user: root
     - group: nagios
     - mode: 660


### PR DESCRIPTION
The nagios server log file location is given by 'nagios_log' in map.jinja rather
than 'nagios_server_log'.

This change should fix #5.
