### PR TITLE
Remove spurious p1_file entry from example pillar

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -103,7 +103,6 @@ nagios:
     low_host_flap_threshold: 5.0
     high_host_flap_threshold: 20.0
     date_format: iso8601
-    p1_file: 
     enable_embedded_perl: 1
     use_embedded_perl_implicitly: 1
     illegal_object_name_chars: `~!$%^&*|'"<>?,(): 


### PR DESCRIPTION
p1_file is not set via pillars, but defined in map.jinja and this entry should
not have made it into the example pillar.
