### PR TITLE
Dynamic commands, services, and NRPE associations

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,6 +30,10 @@ Install nagios plugins.
 
 Install the nagios package and start the nagios service.
 
+``nagios.server.dynamic``
+------------------------
+
+Generate service and command definitions based on pillar data.
 
 ``nagios.nrpe``
 ---------------
@@ -45,6 +49,11 @@ Install the nrpe server.
 ----------------------
 
 Install the nrpe plugin.
+
+``nagios.nrpe.dynamic``
+-----------------------
+
+(Debian only) Generate command definitions and optionally install non-packaged plugins based on pillar data.
 
 ``nagios.nsca.client``
 ----------------------

--- a/nagios/map.jinja
+++ b/nagios/map.jinja
@@ -56,6 +56,9 @@
 }, merge=salt['pillar.get']('nagios:lookup:nagios')) %}
 
 {% set nrpe = salt['grains.filter_by']({
+    'default': {
+        'plugin_dir': '/usr/lib/nagios/plugins',
+    },
     'Arch': {
         'plugin': 'nagios-nrpe-plugin',
         'server': 'nagios-nrpe',

--- a/nagios/nrpe/dynamic.sls
+++ b/nagios/nrpe/dynamic.sls
@@ -1,0 +1,59 @@
+# In order to be useful to Nagios, the NRPE daemon needs needs:
+#
+#  - A check script on minion disk:
+#      e.g. file /usr/lib/nagios/plugins/check_ldap
+#
+#  - A command definition on minion disk:
+#      e.g., /etc/nagios/nrpe.d/disk-space.cfg, which contains: |
+#        command[check_disk_usage]=/usr/lib/nagios/plugins/check_disk arg1 arg2 arg3
+#
+
+{% from "nagios/map.jinja" import nrpe with context %}
+
+{% if grains['os_family'] == 'Debian' %}
+{# TODO: extend this to other OS families; this currently depends on nrpe.d style #}
+
+include:
+  - .server
+  - .plugin
+
+{% if salt['pillar.get']("nagios:checks", False) %}
+{% for check_name, check_def in salt['pillar.get']("nagios:checks").items() %}
+{% if not check_def.get('decommissioned') %}
+{% if 'plugin_file' in check_def['plugin'] %} {# skip checks that are non-NRPE, aka remote checks #}
+{{ check_name }} nagios plugin:
+{% if 'plugin_source' in check_def['plugin'] %}
+  file.managed:
+    - name: {{ nrpe.plugin_dir }}/{{ check_def['plugin']['plugin_file'] }}
+    - source: {{ check_def['plugin']['plugin_source'] }}
+    - mode: 0755
+{% else %}
+  file.exists:
+    - name: {{ nrpe.plugin_dir }}/{{ check_def['plugin']['plugin_file'] }}
+{%- endif %}
+    - require:
+      - pkg: nrpe-plugin-package
+{% endif %}  # plugin_file in check_def['plugin']
+{% endif %}  # decommed
+
+{% if check_def.get('decommissioned') %}
+clear decommissioned {{ check_name }} nrpe command:
+  file.absent:
+    - name: {{ nrpe.cfg_dir }}/{{ check_name }}.cfg
+{% else %}
+{% if 'plugin_file' in check_def['plugin'] %} {# skip checks that are non-NRPE, aka remote checks #}
+{{ check_name }} nrpe command definition:
+  file.managed:
+    - name: {{ nrpe.cfg_dir }}/{{ check_name }}.cfg
+    - contents: |
+        command[{{ check_name }}]={{ nrpe.plugin_dir }}/{{ check_def['plugin']['plugin_file'] }} {{ check_def['plugin'].get('plugin_args', "") }}
+    - require:
+      - pkg: nrpe-plugin-package
+      - file: {{ nrpe.cfg_dir }}
+{% endif %}  # if 'plugin_file' in check_def['plugin']
+{% endif %}  # decommed
+
+{% endfor %}  # end on the minion
+{% endif %}   # if salt['pillar.get']("nagios:checks", False)
+
+{% endif %}  # TODO: extend this to non-Debian os families

--- a/nagios/nrpe/files/nrpe.cfg.jinja
+++ b/nagios/nrpe/files/nrpe.cfg.jinja
@@ -20,6 +20,6 @@ command_timeout={{ nrpe.get('command_timeout', '60') }}
 connection_timeout={{ nrpe.get('connection_timeout', '300') }}
 #allow_weak_random_seed=1
 
-{%- for nrpe_check in nrpe.get('checks', []) %}
-{{ nrpe_check }}
+{%- for nrpe_command in nrpe.get('nrpe_commands', []) %}
+{{ nrpe_command }}
 {%- endfor %}

--- a/nagios/nrpe/plugin.sls
+++ b/nagios/nrpe/plugin.sls
@@ -3,3 +3,9 @@
 nrpe-plugin-package:
   pkg.installed:
     - name: {{ nrpe.plugin }}
+
+{{ nrpe.plugin_dir }}:
+  file.recurse:
+    - source: salt://nagios/nrpe/files/plugins/
+    - clean: False
+    - file_mode: 0755

--- a/nagios/nrpe/server.sls
+++ b/nagios/nrpe/server.sls
@@ -19,6 +19,14 @@ nrpe-server-service:
     - watch_in:
       - service: {{ nrpe.service }}
 
+{% if grains['os_family'] == 'Debian' %}
+{# may be implied by the os_family, but let's be sure #}
+{{ nrpe.cfg_dir }}:
+  file.directory:
+    - require:
+      - pkg: nrpe-server-package
+{% endif %}
+
 {% if grains['os_family'] == 'Arch' %}
 nrpe-group:
   group.present:

--- a/nagios/server/dynamic.sls
+++ b/nagios/server/dynamic.sls
@@ -1,0 +1,97 @@
+
+# In order for Nagios to know to ask a nrpe daemon for a check to be run, or
+# to run a check locally, the following things must be defined on the nagios
+# host, in addition to having the hosts and hostgroups defined elsewhere.
+#
+#  - A global command definition in a nagios config stub: |
+#      define command {
+#        command_name check_disk_usage
+#        command_line $USER1$/check_nrpe -H $HOSTADDRESS$ -c check_disk_usage
+#      }
+#
+#  - A service definition in a nagios config stub: |
+#      define service {
+#        use limited-notification-service
+#        service_description Check for low disk space on any local disks
+#        display_name check_disk
+#        check_command check_disk_usage
+#        hostgroup_name com.example
+#      }
+
+{% from "nagios/map.jinja" import nagios with context %}
+
+{{ nagios.dynamic_cfg_dir }}:
+  file.directory:
+    - makedirs: True
+
+{% for check_name, check_def in salt['pillar.get']("nagios:checks").items() %}
+{% if check_def.get('decommissioned') %}
+clear decommissioned {{ check_name }} global nagios command definition:
+  file.absent:
+    - name: {{ nagios.dynamic_cfg_dir }}/{{ check_name }}.command.global.cfg
+{% else %}
+{{ check_name }} global nagios command definition:
+  file.managed:
+    - name: {{ nagios.dynamic_cfg_dir }}/{{ check_name }}.command.global.cfg
+    - contents: |
+        define command {
+          command_name {{ check_name }}
+{%- if 'command_name' in check_def['plugin'] %}
+          command_line $USER1$/{{ check_def['plugin']['command_name'] }} {{ check_def['plugin'].get('command_args', "") }}
+{%- else %}
+          command_line $USER1$/check_nrpe -H $HOSTADDRESS$ -c {{ check_name }}
+{%- endif %}
+        }
+{% endif %}  # decommed
+    - require:
+      - file: {{ nagios.dynamic_cfg_dir }}
+
+{% if check_def.get('decommissioned') %}
+clear decommissioned {{ check_name }} nagios service definition:
+  file.absent:
+    - name: {{ nagios.dynamic_cfg_dir }}/{{ check_name }}.service.global.cfg
+{% else %}
+{{ check_name }} nagios service definition:
+  file.managed:
+    - name: {{ nagios.dynamic_cfg_dir }}/{{ check_name }}.service.global.cfg
+    - contents: |
+        define service {
+          use {{ check_def['service'].get('template', "limited-notification-service") }}
+          service_description {{ check_def['service']['description'] }}
+          display_name {{ check_name }}
+          check_command {{ check_name }}
+{%- if 'hostgroups' in check_def['service'] %}
+          hostgroup_name {{ check_def['service']['hostgroups']|join(',') }}
+{%- endif %}
+{%- if 'hostnames' in check_def['service'] %}
+          host_name {{ check_def['service']['hostnames']|join(',') }}
+{%- endif %}
+        }
+{% endif %}  # decommed
+    - require:
+      - file: {{ nagios.dynamic_cfg_dir }}
+{% endfor %}
+
+{% if salt['pillar.get']("nagios:pseudohosts", False) %}
+nagios psuedohosts file:
+  file.managed:
+    - name: {{ nagios.dynamic_cfg_dir }}/pseudohosts.cfg
+    - contents: |
+{%- for pseudohost, attributes in salt['pillar.get']("nagios:pseudohosts").items() %}
+        define host {
+          use linux-server
+          host_name {{ pseudohost }}
+{%- if attributes %}{# dict value of None is legal here; if so, skip. #}
+{%- if attributes.get('parent', False) %}
+          parent {{ attributes['parent'] }}
+{%- endif %}
+{%- endif %}
+        }
+{%- endfor %}
+{% else %}
+no stale nagios pseudohost defs:
+  file.absent:
+    - name: {{ nagios.dynamic_cfg_dir }}/pseudohosts.cfg
+{% endif %}
+    - require:
+      - file: {{ nagios.dynamic_cfg_dir }}

--- a/pillar.example
+++ b/pillar.example
@@ -139,12 +139,14 @@ nagios:
       plugins: nagios-plugins
       server: nagios3
       service: nagios3
+      dynamic_cfg_dir: /etc/nagios3/dynamic/
     nrpe:
       plugin: nagios-nrpe-plugin
       plugin_dir: /usr/lib/nagios/plugins/
       cfg_dir: /etc/nagios/nrpe.d/
       server: nagios-nrpe
       service: nrpe
+
 # This pillar data targetted at minion(s) and at the Nagios host, both.
   checks:
     check_procs_ldap:
@@ -162,10 +164,18 @@ nagios:
         hostnames:
           - sololdap.example.com
 
-# This mine function is necessary for the dynamic host/groups generation script (dynamic_cfg.py) 
-# to work. All hosts running the NRPE daemon get this if you want their presence in Nagios host/groups
-# configuration to work.
-mine_functions:
-  nagios_membership:
-    mine_function: pillar.get
-    key: "nagios:checks"
+# This pillar data tree would _only_ be targetted at the Nagios server.
+  pseudohosts:  # You can statically define Nagios hosts (read: non-LDAP) hosts here.
+    admin.example.com:
+      parent: example.com
+    example.com: ~
+  checks:
+    check_example_com_http:  # Example of a remote (read: non-NRPE) check.
+      plugin:
+        command_name: 'check_http'  # defaults to check_nrpe; this is to run local check
+        command_args: '-w 30 -c 60 -H $HOSTADDRESS$ -u /index.html'
+      service:
+        description: "example.com external http check"
+        template: "limited-notification-service"
+        hostnames:
+          - example.com # If a pseudohost, *MUST* be defined above. Does not result in a host definition.

--- a/pillar.example
+++ b/pillar.example
@@ -124,7 +124,7 @@ nagios:
     command_timeout: 60
     connection_timeout: 300
     dont_blame_nrpe: 0
-    checks:
+    nrpe_commands:
       - command[check_users]=/usr/lib/nagios/plugins/check_users -w 5 -c 10
       - command[check_load]=/usr/lib/nagios/plugins/check_load -w 15,10,5 -c 30,25,20
       - command[check_hda1]=/usr/lib/nagios/plugins/check_disk -w 20% -c 10% -p /dev/sda1
@@ -135,9 +135,37 @@ nagios:
       password: s3crIt
       encryption_method: 1
   lookup:
-    nagios_plugins: nagios-plugins
-    nagios_server: nagios3
-    nagios_service: nagios3
-    nrpe_plugin: nagios-nrpe-plugin
-    nrpe_server: nagios-nrpe
-    nrpe_service: nrpe
+    nagios:
+      plugins: nagios-plugins
+      server: nagios3
+      service: nagios3
+    nrpe:
+      plugin: nagios-nrpe-plugin
+      plugin_dir: /usr/lib/nagios/plugins/
+      cfg_dir: /etc/nagios/nrpe.d/
+      server: nagios-nrpe
+      service: nrpe
+# This pillar data targetted at minion(s) and at the Nagios host, both.
+  checks:
+    check_procs_ldap:
+      #decommissioned: True  # Optional indication that the check should be _removed_ from a minion
+      plugin:
+        plugin_file: check_procs
+        #plugin_source: 'salt://ldap/files/check_procs  # optional
+        plugin_args: '-c 1:1 -C slapd'
+      service:
+        description: "slapd process check"
+        template: "critical-service" # default to limited-notification-service
+        hostgroups:
+          - com.example.ldap  # list of applicable nagios hostgroups
+          - com.example       # e.g. for a core check
+        hostnames:
+          - sololdap.example.com
+
+# This mine function is necessary for the dynamic host/groups generation script (dynamic_cfg.py) 
+# to work. All hosts running the NRPE daemon get this if you want their presence in Nagios host/groups
+# configuration to work.
+mine_functions:
+  nagios_membership:
+    mine_function: pillar.get
+    key: "nagios:checks"


### PR DESCRIPTION
This is the first of two forthcoming PRs relating to dynamic Nagios configuration using Salt.

This PR adds the capability to define a Nagios service check in one place in the pillar data, and for both the NRPE-daemon-running minion and the Nagios-running minion to emit appropriate configurations for each. The data added to `pillar.example` illustrates how to use this data. As the author, it's hard to judge how straightforward this is; please let me know if actual documentation is necessary.

There is one breaking change: I changed the name of the `nagios.nrpe.checks` dict (used to embed `command[...]=...` lines directly into `nrpe.cfg`) to be `nagios.nrpe.nrpe_commands`. This is to reduce confusion about where checks (in the broader sense) are defined vs simpler command specifications.

This PR also includes fixes in `pillar.example` relating to use of the `nagios.lookup` dict (and the key names defined therein).

Still TODO is porting the dynamic NRPE configuration emitter states to non-Debian distributions (read: distros which don't do `/etc/nagios/nrpe.d`), and validation that `/usr/lib/nagios/plugins/` is a sane default for `nrpe.plugin_dir` (see `map.jinja`).