### PR TITLE
Multi or none fix

### DIFF
--- a/nagios/nrpe/files/nrpe.cfg.jinja
+++ b/nagios/nrpe/files/nrpe.cfg.jinja
@@ -20,6 +20,8 @@ command_timeout={{ nrpe.get('command_timeout', '60') }}
 connection_timeout={{ nrpe.get('connection_timeout', '300') }}
 #allow_weak_random_seed=1
 
-{%- for nrpe_command in nrpe.get('nrpe_commands', []) %}
-{{ nrpe_command }}
+{%- if nrpe.get('nrpe_commands',[]) is not none  %}
+{%- for nrpe_name, nrpe_command in nrpe.get('nrpe_commands',[]).items() %}
+command[{{ nrpe_name }}]={{ nrpe_command }}
 {%- endfor %}
+{%- endif %}

--- a/pillar.example
+++ b/pillar.example
@@ -186,3 +186,8 @@ nagios3:
   nrpe:
     nrpe_commands:
       check_http: /usr/lib/nagios/plugins/check_http -H localhost -p 80
+
+# If you remove all other NRPE pillars from a host it should still have a blank pillar like so
+nagios3:
+  nrpe:
+    nrpe_commands:

--- a/pillar.example
+++ b/pillar.example
@@ -125,11 +125,11 @@ nagios:
     connection_timeout: 300
     dont_blame_nrpe: 0
     nrpe_commands:
-      - command[check_users]=/usr/lib/nagios/plugins/check_users -w 5 -c 10
-      - command[check_load]=/usr/lib/nagios/plugins/check_load -w 15,10,5 -c 30,25,20
-      - command[check_hda1]=/usr/lib/nagios/plugins/check_disk -w 20% -c 10% -p /dev/sda1
-      - command[check_zombie_procs]=/usr/lib/nagios/plugins/check_procs -w 5 -c 10 -s Z
-      - command[check_total_procs]=/usr/lib/nagios/plugins/check_procs -w 150 -c 200
+      check_users: /usr/lib/nagios/plugins/check_users -w 5 -c 10
+      check_load: /usr/lib/nagios/plugins/check_load -w 15,10,5 -c 30,25,20
+      check_hda1: /usr/lib/nagios/plugins/check_disk -w 20% -c 10% -p /dev/sda1
+      check_zombie_procs: /usr/lib/nagios/plugins/check_procs -w 5 -c 10 -s Z
+      check_total_procs: /usr/lib/nagios/plugins/check_procs -w 150 -c 200
   nsca:
     client:
       password: s3crIt
@@ -179,3 +179,10 @@ nagios:
         template: "limited-notification-service"
         hostnames:
           - example.com # If a pseudohost, *MUST* be defined above. Does not result in a host definition.
+
+# This pillar example will add an additional NRPE check to a web server
+# As long as the base check pillar is included as well this check will be added
+nagios3:
+  nrpe:
+    nrpe_commands:
+      check_http: /usr/lib/nagios/plugins/check_http -H localhost -p 80


### PR DESCRIPTION
Allowing multiple pillars to stack instead of overwrite each other.
This allows for use case specific checks to be added individually to a server through pillars.
It is a change to the way the pillars were formatted and would not be backwards compatible.