### PR TITLE
Clarify relationship, add missing variable

### DIFF
--- a/nagios/nrpe/dynamic.sls
+++ b/nagios/nrpe/dynamic.sls
@@ -15,7 +15,6 @@
 
 include:
   - .server
-  - .plugin
 
 {% if salt['pillar.get']("nagios:checks", False) %}
 {% for check_name, check_def in salt['pillar.get']("nagios:checks").items() %}
@@ -34,7 +33,7 @@ include:
     - name: {{ nrpe.plugin_dir }}/{{ check_def['plugin']['plugin_file'] }}
 {%- endif %}
     - require:
-      - pkg: nrpe-plugin-package
+      - pkg: nrpe-server-package
 {% endif %}  # plugin_file in check_def['plugin']
 {% endif %}  # decommed
 
@@ -47,10 +46,10 @@ clear decommissioned {{ check_name }} nrpe command:
 {{ check_name }} nrpe command definition:
   file.managed:
     - name: {{ nrpe.cfg_dir }}/{{ check_name }}.cfg
-    - contents: |
+    - contents: server
         command[{{ check_name }}]={{ nrpe.plugin_dir }}/{{ check_def['plugin']['plugin_file'] }} {{ check_def['plugin'].get('plugin_args', "") }}
     - require:
-      - pkg: nrpe-plugin-package
+      - pkg: nrpe-server-package
       - file: {{ nrpe.cfg_dir }}
     - watch_in:
       - service: nrpe-server-service


### PR DESCRIPTION
The biggest thing this PR does is it fixes my confusion about which package installs the `check_nrpe` plugin, versus the collection of nagios plugins. Now there are four aspects:
- nagios3 server (`nagios.server`)
- the `check_nrpe` plugin (`nagios.server.nrpe_plugin`)
- nrpe server (`nagios.nrpe.server`)
- nagios plugins, used by both nagios and nrpe (`nagios.plugins`)

Each of these can now be selected individually.

map.jinja also got a `cfg_dir` variable that I missed.
