### PR TITLE
Quote special characters in pillar.example

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -105,8 +105,8 @@ nagios:
     date_format: iso8601
     enable_embedded_perl: 1
     use_embedded_perl_implicitly: 1
-    illegal_object_name_chars: `~!$%^&*|'"<>?,(): 
-    illegal_macro_output_chars: `~$&|'"<>
+    illegal_object_name_chars: "`~!$%^&*|'\"<>?,():"
+    illegal_macro_output_chars: "`~$&|'\"<>"
     use_regexp_matching: 0
     use_true_regexp_matching: 0
     admin_email: root@localhost


### PR DESCRIPTION
The way in which both illegal_object_name_chars and
illegal_macro_output_chars were defined in the example pillar caused
rendering errors in Yaml as `:` was interpreted as being part of a
mapping definition. This patch quotes special characters in there
explicitly and thereby happifies the parser.

See #26 for further details.