### PR TITLE
Add missing 'cfg_dir' setting in map.jinja

### DIFF
--- a/nagios/map.jinja
+++ b/nagios/map.jinja
@@ -91,6 +91,7 @@
         'service': 'nrpe',
     },
     'Debian': {
+	'cfg_dir': '/etc/nagios/nrpe.d',
         'plugin': 'nagios-nrpe-plugin',
         'server': 'nagios-nrpe-server',
         'service': 'nagios-nrpe-server',


### PR DESCRIPTION
This commit fixes #20 by declaring 'cfg_dir' which was forgotten in
5268b10 (merged in #16).