### PR TITLE
fix Debian/Ubuntu default config file name

### DIFF
--- a/nagios/map.jinja
+++ b/nagios/map.jinja
@@ -41,8 +41,8 @@
     },
     'Debian': {
         'check_result_path': '/var/lib/nagios3/spool/checkresults',
-        'conf': '/etc/nagios3/nagios.conf',
-        'cgi_conf': '/etc/nagios3/cgi.conf',
+        'conf': '/etc/nagios3/nagios.cfg',
+        'cgi_conf': '/etc/nagios3/cgi.cfg',
         'command_file': '/var/lib/nagios3/rw/nagios.cmd',
         'debug_file': '/var/log/nagios3/nagios.debug',
         'lock_file': '/var/run/nagios3/nagios3.pid',


### PR DESCRIPTION
Hello,

just observed, that Debian/Ubuntu uses nagios.cfg and cgi.cfg config filenames. This should fix defaults from nagios.conf to nagios.cfg and cgi.conf to cgi.cfg respectively.