### PR TITLE
Perform safe nrpe_commands pillar lookup

### DIFF
--- a/nagios/nrpe/files/nrpe.cfg.jinja
+++ b/nagios/nrpe/files/nrpe.cfg.jinja
@@ -20,12 +20,14 @@ command_timeout={{ nrpe.get('command_timeout', '60') }}
 connection_timeout={{ nrpe.get('connection_timeout', '300') }}
 #allow_weak_random_seed=1
 
-{%- if nrpe['nrpe_commands'] is mapping %}
-{%- for nrpe_command in nrpe['nrpe_commands'].values() %}
+{%- if nrpe.nrpe_commands is defined %}
+{%- if nrpe.get('nrpe_commands') is mapping %}
+{%- for nrpe_command in nrpe.get('nrpe_commands').values() %}
 {{ nrpe_command }}
 {%- endfor %}
-{%- elif nrpe['nrpe_commands'] is iterable %}
-{%- for nrpe_command in nrpe.get('nrpe_commands', []) %}
+{%- elif nrpe.get('nrpe_commands') is iterable %}
+{%- for nrpe_command in nrpe.get('nrpe_commands') %}
 {{ nrpe_command }}
 {%- endfor %}
+{%- endif %}
 {%- endif %}


### PR DESCRIPTION
This used to break if nrpe_commands wasn't defined in the pillar. See #27 for details.