### PR TITLE
disable need for nrpe_commands, avoid definition of plugin_dir in yaml

### DIFF
--- a/nagios/map.jinja
+++ b/nagios/map.jinja
@@ -91,7 +91,8 @@
         'service': 'nrpe',
     },
     'Debian': {
-	'cfg_dir': '/etc/nagios/nrpe.d',
+        'cfg_dir': '/etc/nagios/nrpe.d',
+        'plugin_dir': '/usr/lib/nagios/plugins',
         'plugin': 'nagios-nrpe-plugin',
         'server': 'nagios-nrpe-server',
         'service': 'nagios-nrpe-server',


### PR DESCRIPTION
default of 'plugin_dir' does not work with debian, unless it is defined in the 'Debian' section

'nrpe.cfg' does not compile if 'nrpe_command' is not defined in yaml-file. But it should compile even if you have no nrpe_command defined.

It would also solve problems mentioned in issue  #28