### PR TITLE
Pull resource.cfg data from pillar

### DIFF
--- a/nagios/server/files/resource.cfg
+++ b/nagios/server/files/resource.cfg
@@ -14,34 +14,6 @@ $USER2$={{ nagios.get('USER2', '#$USER2$=/usr/lib/nagios/plugins/eventhandlers')
 {% endif %}
 
 # Store some usernames and passwords (hidden from the CGIs)
-{% if nagios.get('USER3') %}
-$USER3$={{ nagios.get('USER3', '#$USER3$=someuser') }}
-{% endif %}
-
-{% if nagios.get('USER4') %}
-$USER4$={{ nagios.get('USER4', '#$USER4$=somepassword') }}
-{% endif %}
-
-{% if nagios.get('USER5') %}
-$USER5$={{ nagios.get('USER5', '#$USER5$=someuser') }}
-{% endif %}
-
-{% if nagios.get('USER6') %}
-$USER6$={{ nagios.get('USER6', '#$USER6$=somepassword') }}
-{% endif %}
-
-{% if nagios.get('USER7') %}
-$USER7$={{ nagios.get('USER7', '#$USER7$=someuser') }}
-{% endif %}
-
-{% if nagios.get('USER8') %}
-$USER8$={{ nagios.get('USER8', '#$USER8$=somepassword') }}
-{% endif %}
-
-{% if nagios.get('USER9') %}
-$USER9$={{ nagios.get('USER9', '#$USER9$=someuser') }}
-{% endif %}
-
-{% if nagios.get('USER10') %}
-$USER10$={{ nagios.get('USER10', '#$USER10$=somepassword') }}
-{% endif %}
+{% for user, user_context in nagios.get('macro_users', {}).items() %}
+${{ user }}$={{ user_context }}
+{% endfor %}

--- a/nagios/server/files/resource.cfg
+++ b/nagios/server/files/resource.cfg
@@ -10,7 +10,7 @@ $USER1$={{ nagios.get('plugin_dir', '/usr/lib/nagios/plugins') }}
 
 # Sets $USER2$ to be the path to event handlers
 {% if nagios.get('USER2') %}
-$USER2$={{ nagios.get('USER2', '#$USER2$=/usr/lib/nagios/plugins/eventhandlers') }}
+$USER2$={{ nagios.get('USER2') }}
 {% endif %}
 
 # Store some usernames and passwords (hidden from the CGIs)

--- a/nagios/server/files/resource.cfg
+++ b/nagios/server/files/resource.cfg
@@ -9,8 +9,39 @@
 $USER1$={{ nagios.get('plugin_dir', '/usr/lib/nagios/plugins') }}
 
 # Sets $USER2$ to be the path to event handlers
-#$USER2$=/usr/lib/nagios/plugins/eventhandlers
+{% if nagios.get('USER2') %}
+$USER2$={{ nagios.get('USER2', '#$USER2$=/usr/lib/nagios/plugins/eventhandlers') }}
+{% endif %}
 
 # Store some usernames and passwords (hidden from the CGIs)
-#$USER3$=someuser
-#$USER4$=somepassword
+{% if nagios.get('USER3') %}
+$USER3$={{ nagios.get('USER3', '#$USER3$=someuser') }}
+{% endif %}
+
+{% if nagios.get('USER4') %}
+$USER4$={{ nagios.get('USER4', '#$USER4$=somepassword') }}
+{% endif %}
+
+{% if nagios.get('USER5') %}
+$USER5$={{ nagios.get('USER5', '#$USER5$=someuser') }}
+{% endif %}
+
+{% if nagios.get('USER6') %}
+$USER6$={{ nagios.get('USER6', '#$USER6$=somepassword') }}
+{% endif %}
+
+{% if nagios.get('USER7') %}
+$USER7$={{ nagios.get('USER7', '#$USER7$=someuser') }}
+{% endif %}
+
+{% if nagios.get('USER8') %}
+$USER8$={{ nagios.get('USER8', '#$USER8$=somepassword') }}
+{% endif %}
+
+{% if nagios.get('USER9') %}
+$USER9$={{ nagios.get('USER9', '#$USER9$=someuser') }}
+{% endif %}
+
+{% if nagios.get('USER10') %}
+$USER10$={{ nagios.get('USER10', '#$USER10$=somepassword') }}
+{% endif %}

--- a/pillar.example
+++ b/pillar.example
@@ -141,7 +141,8 @@ nagios:
       server: nagios3
       service: nagios3
       dynamic_cfg_dir: /etc/nagios3/dynamic/
-      USER3: "'s3crIt'"
+      macro_users:
+        USER3: "'s3crIt'"
     nrpe:
       plugin: nagios-nrpe-plugin
       plugin_dir: /usr/lib/nagios/plugins/

--- a/pillar.example
+++ b/pillar.example
@@ -141,6 +141,7 @@ nagios:
       server: nagios3
       service: nagios3
       dynamic_cfg_dir: /etc/nagios3/dynamic/
+      USER3: "'s3crIt'"
     nrpe:
       plugin: nagios-nrpe-plugin
       plugin_dir: /usr/lib/nagios/plugins/


### PR DESCRIPTION
This allows one to populate the pillar with username/password data that will be injected in to the resource config file - making it available for nagios checks. Each of the references are an optional pillar item and I also included the event handler reference as well. 
