### PR TITLE
nrpe.cfg: allowed_hosts should accept multiple hosts and output in comma-delimi…

### DIFF
--- a/nagios/nrpe/files/nrpe.cfg.jinja
+++ b/nagios/nrpe/files/nrpe.cfg.jinja
@@ -15,7 +15,15 @@ server_address={{ nrpe.get('server_address', '127.0.0.1') }}
 {% endif %}
 nrpe_user={{ nrpe_map.get('user', 'nagios') }}
 nrpe_group={{ nrpe_map.get('group', 'nagios') }}
-allowed_hosts={{ nrpe.get('allowed_hosts', '127.0.0.1') }}
+{%- if nrpe.allowed_hosts is defined %}
+  {%- if nrpe.allowed_hosts is iterable and nrpe.allowed_hosts is not string %}
+allowed_hosts={{ nrpe.allowed_hosts | join(',') }}
+  {%- else %}
+allowed_hosts={{ nrpe.allowed_hosts }}
+  {%- endif %}
+{%- else %}
+allowed_hosts=127.0.0.1
+{%- endif %}
 dont_blame_nrpe={{ nrpe.get('dont_blame_nrpe', 0) }}
 # command_prefix=/usr/bin/sudo
 debug=0

--- a/nagios/nrpe/files/nrpe.cfg.jinja
+++ b/nagios/nrpe/files/nrpe.cfg.jinja
@@ -15,14 +15,10 @@ server_address={{ nrpe.get('server_address', '127.0.0.1') }}
 {% endif %}
 nrpe_user={{ nrpe_map.get('user', 'nagios') }}
 nrpe_group={{ nrpe_map.get('group', 'nagios') }}
-{%- if nrpe.allowed_hosts is defined %}
-  {%- if nrpe.allowed_hosts is iterable and nrpe.allowed_hosts is not string %}
+{%- if nrpe.allowed_hosts is defined and nrpe.allowed_hosts is iterable and nrpe.allowed_hosts is not string %}
 allowed_hosts={{ nrpe.allowed_hosts | join(',') }}
-  {%- else %}
-allowed_hosts={{ nrpe.allowed_hosts }}
-  {%- endif %}
 {%- else %}
-allowed_hosts=127.0.0.1
+allowed_hosts={{ nrpe.allowed_hosts | default('127.0.0.1') }}
 {%- endif %}
 dont_blame_nrpe={{ nrpe.get('dont_blame_nrpe', 0) }}
 # command_prefix=/usr/bin/sudo

--- a/pillar.example
+++ b/pillar.example
@@ -121,7 +121,9 @@ nagios:
     server_address: 127.0.0.1
     server_port: 5666
     pid_file: /var/run/nagios/nrpe.pid
-    allowed_hosts: 127.0.0.1
+    allowed_hosts:
+      - 127.0.0.1
+      - 192.168.0.1
     command_timeout: 60
     connection_timeout: 300
     dont_blame_nrpe: 0


### PR DESCRIPTION
…ted format
```
nrpe.cfg
# Sample NRPE Config File
# ALLOWED HOST ADDRESSES
# This is an optional comma-delimited list of IP address or hostnames 
# that are allowed to talk to the NRPE daemon.
...

allowed_hosts=127.0.0.1