### PR TITLE
Handle FreeBSD default nrpe config.

### DIFF
--- a/nagios/nrpe/server.sls
+++ b/nagios/nrpe/server.sls
@@ -9,6 +9,17 @@ nrpe-server-service:
     - name: {{ nrpe.service }}
     - enable: true
 
+{% if grains['os'] == 'FreeBSD' %}
+/usr/local/etc/nrpe.cfg:
+   file.managed:
+    - source: salt://nagios/nrpe/files/nrpe.cfg.jinja
+    - template: jinja
+    - user: root
+    - group: wheel
+    - mode: 644
+    - watch_in:
+      - service: {{ nrpe.service }}
+{% else %}
 /etc/nagios/nrpe.cfg:
    file.managed:
     - source: salt://nagios/nrpe/files/nrpe.cfg.jinja
@@ -18,6 +29,7 @@ nrpe-server-service:
     - mode: 644
     - watch_in:
       - service: {{ nrpe.service }}
+{% endif %}
 
 {% if grains['os_family'] == 'Debian' %}
 {# may be implied by the os_family, but let's be sure #}


### PR DESCRIPTION
Since default nrpe config path is hadcoded, there is no way to handle that file. Also notice that root group in freebsd doesn't exists.