### PR TITLE
Update nrpe server and service for FreeBSD

### DIFF
--- a/nagios/map.jinja
+++ b/nagios/map.jinja
@@ -143,8 +143,8 @@
         'group': 'nagios',
         'plugin': 'nagios-plugins',
         'plugin_dir': '/usr/local/libexec/nagios',
-        'server': 'nrpe-ssl',
-        'service': 'nrpe2',
+        'server': 'nrpe3',
+        'service': 'nrpe3',
     },
 }, merge=salt['pillar.get']('nagios:lookup:nrpe')) %}
 


### PR DESCRIPTION
Nrpe 2 was deprecated see https://www.freshports.org/net-mgmt/nrpe-ssl/