### PR TITLE
Add compability to use nrpe on RedHat os_family with nrpe.d style

### DIFF
--- a/nagios/map.jinja
+++ b/nagios/map.jinja
@@ -132,8 +132,10 @@
         'user': 'nagios',
     },
     'RedHat': {
+        'cfg_dir': '/etc/nagios/nrpe.d',
         'group': 'nrpe',
         'plugin': 'nagios-plugins-all',
+        'plugin_dir': '/usr/lib64/nagios/plugins',
         'server': 'nrpe',
         'service': 'nrpe',
         'user': 'nrpe',

--- a/nagios/nrpe/dynamic.sls
+++ b/nagios/nrpe/dynamic.sls
@@ -10,8 +10,7 @@
 
 {% from "nagios/map.jinja" import nrpe with context %}
 
-{% if grains['os_family'] == 'Debian' %}
-{# TODO: extend this to other OS families; this currently depends on nrpe.d style #}
+{% if grains['os_family'] in ['Debian','RedHat']  %}
 
 include:
   - .server
@@ -60,4 +59,4 @@ clear decommissioned {{ check_name }} nrpe command:
 {% endfor %}  # end on the minion
 {% endif %}   # if salt['pillar.get']("nagios:checks", False)
 
-{% endif %}  # TODO: extend this to non-Debian os families
+{% endif %}  #

--- a/nagios/nrpe/server.sls
+++ b/nagios/nrpe/server.sls
@@ -19,12 +19,17 @@ nrpe-server-service:
     - watch_in:
       - service: {{ nrpe.service }}
 
-{% if grains['os_family'] == 'Debian' %}
-{# may be implied by the os_family, but let's be sure #}
 {{ nrpe.cfg_dir }}:
   file.directory:
     - require:
-      - pkg: nrpe-server-package
+      - pkg: {{ nrpe.server }}
+
+{% if grains['os_family'] == 'RedHat' %}
+{# create link on Redhat to be more close to debian and other distributions #}
+nagios_plugins_sym:
+  file.symlink:
+    - name: /usr/lib/nagios
+    - target: /usr/lib64/nagios
 {% endif %}
 
 {% if grains['os_family'] == 'Arch' %}


### PR DESCRIPTION
Add the conf.d behaviour to redhat systems to use the better yaml syntax of defining nagios checks