### PR TITLE
add ocsp_command in nagios.cfg

### DIFF
--- a/nagios/server/files/nagios.cfg
+++ b/nagios/server/files/nagios.cfg
@@ -63,6 +63,7 @@ host_check_timeout={{ server.get('host_check_timeout', 30) }}
 event_handler_timeout={{ server.get('event_handler_timeout', 30) }}
 notification_timeout={{ server.get('notification_timeout', 30) }}
 ocsp_timeout={{ server.get('ocsp_timeout', 5) }}
+{% if server.ocsp_command is not defined %}#{% endif %}ocsp_command={{ server.get('ocsp_command', 'somecommand') }}
 perfdata_timeout={{ server.get('perfdata_timeout', 5) }}
 retain_state_information={{ server.get('retain_state_information', 1) }}
 state_retention_file={{ nagios.state_retention_file }}

--- a/pillar.example
+++ b/pillar.example
@@ -63,6 +63,8 @@ nagios:
     event_handler_timeout: 30
     notification_timeout: 30
     ocsp_timeout: 5
+    # This option allows you to specify a command to be run after every service check, which can be useful in distributed monitoring.
+    # ocsp_command: obsessive_service_handler
     perfdata_timeout: 5
     retain_state_information: 1
     retention_update_interval: 60


### PR DESCRIPTION
With this PR it will be possible to use the ocsp_command and configure it via pillars. If pillar is not set, this optin will be only a comment in the config file.