### PR TITLE
Fix pid_file path on redhat.

### DIFF
--- a/nagios/map.jinja
+++ b/nagios/map.jinja
@@ -137,6 +137,7 @@
         'server': 'nrpe',
         'service': 'nrpe',
         'user': 'nrpe',
+        'pid_file': '/var/run/nrpe/nrpe.pid',
     },
     'FreeBSD': {
         'cfg_dir': '/usr/local/etc/nrpe.d',


### PR DESCRIPTION
On Redhat, nrpe runs as user nrpe, not nagios.

Directory /var/run/nrpe is automatically created and owned by nrpe.

Should fix #51