### PR TITLE
nrpe/dynamic: mode for cmd files (nrpe.d/*)

### DIFF
--- a/nagios/map.jinja
+++ b/nagios/map.jinja
@@ -130,6 +130,7 @@
         'server': 'nagios-nrpe-server',
         'service': 'nagios-nrpe-server',
         'user': 'nagios',
+        'cmd_mode': 0644,
     },
     'RedHat': {
         'group': 'nrpe',

--- a/nagios/nrpe/dynamic.sls
+++ b/nagios/nrpe/dynamic.sls
@@ -47,6 +47,7 @@ clear decommissioned {{ check_name }} nrpe command:
 {{ check_name }} nrpe command definition:
   file.managed:
     - name: {{ nrpe.cfg_dir }}/{{ check_name }}.cfg
+    - mode: {{ nrpe.cmd_mode }}
     - contents: |
         command[{{ check_name }}]={{ nrpe.plugin_dir }}/{{ check_def['plugin']['plugin_file'] }} {{ check_def['plugin'].get('plugin_args', "") }}
     - require:

--- a/pillar.example
+++ b/pillar.example
@@ -156,6 +156,7 @@ nagios:
       server: nagios-nrpe
       service: nrpe
       user: nagios
+      cmd_mode: 644  # nagios.nrpe.dynamic - /etc/nagios/nrpe.d/* files modes
 
 # This pillar data targetted at minion(s) and at the Nagios host, both.
   checks:


### PR DESCRIPTION
Explictly set mode for those files, as they would not work if not readable by
nrpe.