### PR TITLE
nrpe: fix default pid_file for RedHat

### DIFF
--- a/nagios/nrpe/files/nrpe.cfg.jinja
+++ b/nagios/nrpe/files/nrpe.cfg.jinja
@@ -8,7 +8,7 @@
 #
 
 log_facility=daemon
-pid_file={{ nrpe.get('pid_file', '/var/run/nagios/nrpe.pid') }}
+pid_file={{ nrpe_map.get('pid_file', '/var/run/nagios/nrpe.pid') }}
 server_port={{ nrpe.get('server_port', '5666') }}
 {% if nrpe.get('server_address') %}
 server_address={{ nrpe.get('server_address', '127.0.0.1') }}


### PR DESCRIPTION
pid_file has a working default value defined in map.jinja for RedHat,
but it wasn't take in account because we look in "nrpe" variable instead
of "nrpe_map" (merged lookup with defaults) in the template.