### PR TITLE
[nagios/nrpe/server] add require between config file and pkg

### DIFF
--- a/nagios/nrpe/server.sls
+++ b/nagios/nrpe/server.sls
@@ -17,6 +17,8 @@ nrpe-server-service:
     - user: root
     - group: wheel
     - mode: 644
+    - require:
+      - pkg: nrpe-server-package
     - watch_in:
       - service: {{ nrpe.service }}
 {% else %}
@@ -27,6 +29,8 @@ nrpe-server-service:
     - user: root
     - group: root
     - mode: 644
+    - require:
+      - pkg: nrpe-server-package
     - watch_in:
       - service: {{ nrpe.service }}
 {% endif %}


### PR DESCRIPTION
This can be important if the install part fails. 

On RHEL the package will set some selinux context on `/etc/nagios/nrpe.conf` so if the file has been deployed before the package the service won't be able to read the file. See : https://superuser.com/questions/1088817/nrpe-centos-7-could-not-open-config-directory