### PR TITLE
set cmd_mode on RedHat

### DIFF
--- a/nagios/osfamilymap.yaml
+++ b/nagios/osfamilymap.yaml
@@ -142,6 +142,7 @@ RedHat:
     plugin: nagios-plugins-all
     plugin_dir: /usr/lib64/nagios/plugins
     pid_file: /var/run/nrpe/nrpe.pid
+    cmd_mode: 0644
 
 SuSE:
   nrpe:


### PR DESCRIPTION
nagios/nrpe/dynamic.sls requires the variable to be set when the
os_family is either Debian or RedHat, not just Debian.

Signed-off-by: Matthew Thode <mthode@mthode.org>